### PR TITLE
Add basic python logging template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # codex
+
+This repository contains a simple Python program that demonstrates
+logging to both a file and the console. A sample Windows batch file is
+included for running the script with example arguments.
+
+## Usage
+
+```bash
+python main.py foo1 --log myapp.log
+```
+
+Alternatively on Windows you can double‑click or run `run.bat`.
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,43 @@
+import argparse
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def setup_logging(logfile: str) -> None:
+    """Configure logging to file and stdout."""
+    formatter = logging.Formatter(
+        fmt="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    fh = logging.FileHandler(logfile, encoding="utf-8")
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(formatter)
+    logger.addHandler(sh)
+
+
+def main(args: argparse.Namespace) -> None:
+    """Main entry point."""
+    logger.info("Start program with args: %s", args)
+    try:
+        logger.info("Processing...")
+        # ... add application logic here ...
+        logger.info("Done.")
+    except Exception:
+        logger.exception("Unhandled exception occurred")
+        raise  # Re-raise if needed
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Sample application")
+    parser.add_argument("foo", help="Positional argument")
+    parser.add_argument("--log", default="app.log", help="Log file name")
+    parsed = parser.parse_args()
+    setup_logging(parsed.log)
+    main(parsed)

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,4 @@
+@echo off
+REM Run the sample application with example arguments
+python main.py foo1 --log myapp.log
+


### PR DESCRIPTION
## Summary
- add `main.py` with logging and CLI args
- add `run.bat` to run example on Windows
- document usage in `README.md`

## Testing
- `python main.py foo1 --log test.log`

------
https://chatgpt.com/codex/tasks/task_e_68625110eef48320992d7a48b75cabbc